### PR TITLE
Allow more than just alphabetic function names

### DIFF
--- a/functions/callbacks.py
+++ b/functions/callbacks.py
@@ -9,7 +9,8 @@ import typer
 from functions import __version__
 from functions import __project_name__
 from functions import styles
-from functions.validators import str_is_alpha_validator
+from functions.decorators import resilient_parsing
+from functions.validators import name_validator
 from functions.types import LocalFunctionPath
 from functions.input import confirm_abort
 
@@ -26,24 +27,20 @@ def version_callback(value: bool) -> None:
 def function_name_callback(
     ctx: typer.Context, param: typer.CallbackParam, value: str
 ) -> Optional[str]:
-    if ctx.resilient_parsing:
-        return None
 
     try:
-        # TODO: Update this to correctly filter invalid names (regex?)
-        str_is_alpha_validator(value)
+        name_validator(value)
     except ValueError:
         raise typer.BadParameter(
-            "Only alphabetic characters are allowed as function names"
+            "Only alphabetic characters with '-' and '_' characters are allowed as function names"
         )
     return value
 
 
+@resilient_parsing
 def function_name_autocomplete_callback(
     ctx: typer.Context, param: typer.CallbackParam, value: str
 ) -> Optional[str]:
-    if ctx.resilient_parsing:
-        return None
 
     build_functions = list(autocomplete_function_names(""))
     # TODO: Check if the container is running and abort if it already is running

--- a/functions/decorators.py
+++ b/functions/decorators.py
@@ -21,7 +21,7 @@ def handle_error(
     Decorator that gracefully handles errors.
     """
 
-    def handle(_func: "AnyCallableT"):
+    def handle(_func: AnyCallableT):
         @functools.wraps(_func)
         def command(*args: Any, **kwargs: Any) -> Any:
             try:
@@ -52,5 +52,19 @@ def handle_error(
         return handle
 
 
+CallbackCallable = Callable[[typer.Context, typer.CallbackParam, str], Optional[str]]
 
-# TODO: Add a callback decorator to handle resi...something
+
+def resilient_parsing(func) -> CallbackCallable:
+    """Wraps a callback functions to return for resilient parsing [Typer]"""
+
+    @functools.wraps(func)
+    def wrapper(
+        ctx: typer.Context, param: typer.CallbackParam, value: str
+    ) -> Optional[str]:
+        if ctx.resilient_parsing:
+            return None
+
+        return func(ctx, param, value)
+
+    return wrapper

--- a/functions/validators.py
+++ b/functions/validators.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +23,7 @@ def path_has_config_validator(v: Any) -> Path:
     return v
 
 
-def str_is_alpha_validator(v: str) -> str:
-    if not v.isalpha():
-        raise ValueError("Not an alphabetic string")
+def name_validator(v: str) -> str:
+    if not re.match("^[a-zA-Z0-9_-]*$", v):
+        raise ValueError("Value does not match name requirements")
     return v


### PR DESCRIPTION
Add a resilient parsing validator and update the "str" validator to be a name validator.

Closes #21 