### PR TITLE
Add optional description in config

### DIFF
--- a/functions/commands/new.py
+++ b/functions/commands/new.py
@@ -6,12 +6,14 @@ import typer
 from functions import defaults
 from functions.arguments import FunctionNameArgument
 from functions.callbacks import function_dir_callback
+from functions.constants import SignatureType
 from functions.system import add_required_files
 
 app = typer.Typer(help="Factory method for creating new functions")
 
 
 # TODO: Consider adding a new to the configuration file if decide to do anything with it.
+
 
 @app.command()
 def pubsub(
@@ -29,7 +31,7 @@ def pubsub(
         function_name,
         function_dir,
         main_content=defaults.default_entry_hello_pubsub,
-        signature_type="event",
+        signature_type=SignatureType.PUBSUB,
     )
 
     typer.echo(f"Added a new pubsub function -> {function_dir}")
@@ -51,7 +53,7 @@ def http(
         function_name,
         function_dir,
         main_content=defaults.default_entry_hello_http,
-        signature_type="http",
+        signature_type=SignatureType.HTTP,
     )
 
     typer.echo(f"Added a new http function to -> {function_dir}")

--- a/functions/config.py
+++ b/functions/config.py
@@ -2,19 +2,20 @@
 from __future__ import annotations
 import os
 from pathlib import Path
-from typing import Any, NoReturn
+from typing import Any, Optional
 from typing import Dict
 from typing import List
 from typing import Type
 
-import toml # type: ignore
+import toml  # type: ignore
 from pydantic import BaseModel
 
-from functions.types import CallableGenerator, StrBytes
+from functions.types import CallableGenerator
 
 BASE_DIR_NAME = "ventress-functions"
 
 # TODO: Rewrite this in a way that makes sense
+
 
 class BaseConfig:
     """Base class for the configuration file to enforce a standard interface"""
@@ -38,19 +39,21 @@ class BaseConfig:
 
 class AppFiles(BaseModel):
     """Represents the names of files the relate to this application"""
+
     history_file: str = "command_history"
     functions_file: str = "functions_registry"
 
 
 class AppFunction(BaseModel):
     """Stores a configuration of a specific funcion"""
+
     name: str
     config: FunctionConfig
 
 
-
 class AppConfig(BaseModel, BaseConfig):
     """Holds all the variables for the config file"""
+
     default_region: str = ""
     files: AppFiles = AppFiles()
     functions: List[AppFunction] = []
@@ -145,6 +148,7 @@ app_config.load_config()
 # FunctionConfig
 class RunVariables(BaseModel):
     """Holds the run time variables"""
+
     entry_point: str
     name: str
     port: int
@@ -154,19 +158,23 @@ class RunVariables(BaseModel):
 
 class EnvVariables(Dict[str, str]):
     """Holds environmental variables"""
+
     ...
 
 
 class DeployVariables(BaseModel):
     """Holds deploy specific variables"""
-    allow_unauthenticated = False
+
+    allow_unauthenticated: Optional[bool]
     provider: str
     service: str
 
 
 class FunctionConfig(BaseModel):
     """Represents a configuration file of a specific function"""
-    path: str
+
+    path: Optional[str]
+    description: str
     run_variables: RunVariables
     env_variables: EnvVariables
     deploy_variables: DeployVariables

--- a/functions/constants.py
+++ b/functions/constants.py
@@ -6,6 +6,9 @@ class ConfigName(str, Enum):
     BASE = "config.json"
 
 
+class SignatureType(str, Enum):
+    PUBSUB = "event"
+    HTTP = "http"
 
 class DockerLabel(str, Enum):
     """Stores constants under which variables are stored"""

--- a/functions/defaults.py
+++ b/functions/defaults.py
@@ -1,9 +1,14 @@
 from functions.config import FunctionConfig
+from functions.constants import SignatureType
+from functions.validators import name_validator
 
-# TODO: Add a validator that checks for correct name
-def default_config(function_name: str, signature_type: str) -> FunctionConfig:
-    return FunctionConfig(
+
+def default_config(function_name: str, signature_type: SignatureType) -> FunctionConfig:
+    name_validator(function_name)
+
+    config = FunctionConfig(
         **{
+            "description": f"Generated functions template called '{function_name}' of '{signature_type}' type",
             "run_variables": {
                 "source": "main.py",
                 "entry_point": "main",
@@ -15,11 +20,13 @@ def default_config(function_name: str, signature_type: str) -> FunctionConfig:
             "deploy_variables": {
                 "provider": "gcp",
                 "service": "cloud_function",
-                # TODO: Add only if signature_type type allows
-                "allow_unauthenticated": False,  # Consider taking a prompt
             },
         }
     )
+    if signature_type == SignatureType.HTTP:
+        config.deploy_variables.allow_unauthenticated = False
+
+    return config
 
 
 default_entry_hello_pubsub = """

--- a/functions/system.py
+++ b/functions/system.py
@@ -6,7 +6,7 @@ from typing import Union
 from pydantic import validate_arguments
 
 from functions import defaults
-from functions.constants import ConfigName
+from functions.constants import ConfigName, SignatureType
 from functions.types import LocalFunctionPath
 from functions.config import FunctionConfig
 
@@ -54,7 +54,7 @@ def link_common(function_dir: str):
 
 
 def add_required_files(
-    function_name: str, function_dir: str, *, main_content: str, signature_type: str
+    function_name: str, function_dir: str, *, main_content: str, signature_type: SignatureType
 ):
     """Add required files into the function directory"""
     # Make a new directory


### PR DESCRIPTION
Add a signature type enum. Adjust the function config to take a description and optional unauthenticated variable. Adjust the default configuration with changed config fields.

Resolves #28 